### PR TITLE
Adds "Date Tweeted" column to the Entry index view

### DIFF
--- a/socialposter/SocialPosterPlugin.php
+++ b/socialposter/SocialPosterPlugin.php
@@ -109,6 +109,30 @@ class SocialPosterPlugin extends BasePlugin
         }
     }
 
+    public function defineAdditionalEntryTableAttributes()
+    {
+        return array(
+            'dateTweeted' => "Date Tweeted",
+        );
+    }
+
+    public function getEntryTableAttributeHtml(EntryModel $entry, $attribute)
+    {
+        switch ($attribute) {
+            case 'dateTweeted':
+
+                $posts = craft()->socialPoster_posts->getAllByElementId($entry->id);
+
+                if ($posts && $posts['twitter']) {
+                    $dateTweeted = $posts['twitter']->dateCreated;
+                    return '<span title="'.$dateTweeted->localeDate().' '.$dateTweeted->localeTime().'">'.$dateTweeted->uiTimestamp().'</span>';
+                } else {
+                    return '--';
+                }
+
+                break;
+        }
+    }
 
     // =========================================================================
     // HOOKS


### PR DESCRIPTION
You can now add an optional "Date Tweeted" column to the entry index view...

<img width="120" alt="screen shot 2017-01-08 at 12 02 34 am" src="https://cloud.githubusercontent.com/assets/5309692/21748279/df0968ca-d535-11e6-9096-e23f21fa6d18.png">

---

Closes #10 